### PR TITLE
Python 3 updates broke binary file handling

### DIFF
--- a/pyblue/main.py
+++ b/pyblue/main.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals, print_function
 
 import bottle
+import magic
 from mako.lookup import TemplateLookup
 from mako import exceptions
 import os, os.path, itertools
@@ -29,9 +30,14 @@ class File(object):
 
         self.meta  =  dict(name=self.nice_name, sortkey="5", tags=set("data"), doctype="markdown")
 
-        # large files should not be parsed
-        if not self.skip_file:
+        # large files and binary files should not be parsed
+        if not self.skip_file and self.mime_type.startswith('text'):
             self.meta.update(utils.parse_meta(self.fpath))
+
+    @property
+    def mime_type(self):
+        "Returns mime-type of the file as determed by magic library"
+        return magic.from_file(self.fpath, mime=True).decode('ascii')
 
     @property
     def nice_name(self):

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(name='pyblue',
         "markdown",
         "waitress",
         "docutils",
+        "python-magic",
         ],
      )
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -45,5 +45,9 @@ class TestSequenceFunctions(unittest.TestCase):
         value = self.pyblue.get(File("test.html", root=self.pyblue.folder))
         self.assertEqual(value.strip(), b"<h1>Test</h1>")
 
+    def test_image(self):
+        self.pyblue.set_folder(os.path.join(_folder, "input_image"))
+        self.pyblue.get(File("test.png", root=self.pyblue.folder))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The switch to unicode strings broke the parse_meta function when it handles binary files.  parse_meta probably shouldn't be handling binary files anyway.

I added the python-magic library to determine file type by magic number.  I figured it was either this, or determining which files to run parse_meta on based on file extension.  Other suggestions?

Thanks!
